### PR TITLE
Use final where possible and disallow construction of utility classes

### DIFF
--- a/src/main/java/com/sanctionco/jmail/Email.java
+++ b/src/main/java/com/sanctionco/jmail/Email.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * Represents an email address.
  */
-public class Email {
+public final class Email {
   private final String localPart;
   private final String localPartWithoutComments;
   private final String domain;
@@ -136,7 +136,7 @@ public class Email {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof Email)) return false;
     Email email = (Email) o;
     return localPart.equals(email.localPart)
         && domain.equals(email.domain);

--- a/src/main/java/com/sanctionco/jmail/EmailValidator.java
+++ b/src/main/java/com/sanctionco/jmail/EmailValidator.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  *     .tryParse("test@test.com");
  * </pre>
  */
-public class EmailValidator {
+public final class EmailValidator {
   // Define some predicates here so that when adding them to the set of validation
   // predicates we protect against adding them multiple times.
   private static final Predicate<Email> DISALLOW_IP_DOMAIN_PREDICATE

--- a/src/main/java/com/sanctionco/jmail/InvalidEmailException.java
+++ b/src/main/java/com/sanctionco/jmail/InvalidEmailException.java
@@ -4,7 +4,7 @@ package com.sanctionco.jmail;
  * A {@link RuntimeException} that indicates an invalid email was encountered during
  * validation.
  */
-public class InvalidEmailException extends RuntimeException {
+public final class InvalidEmailException extends RuntimeException {
 
   /**
    * Construct a new instance of {@code InvalidEmailException}.

--- a/src/main/java/com/sanctionco/jmail/JMail.java
+++ b/src/main/java/com/sanctionco/jmail/JMail.java
@@ -15,7 +15,8 @@ import java.util.stream.Collectors;
  * Provides static methods to validate an email address
  * using standard validation, or to create a new {@link EmailValidator}.
  */
-public class JMail {
+public final class JMail {
+  private JMail() {}
 
   /**
    * Returns a new instance of {@link EmailValidator}. In general,

--- a/src/main/java/com/sanctionco/jmail/ValidationRules.java
+++ b/src/main/java/com/sanctionco/jmail/ValidationRules.java
@@ -9,7 +9,9 @@ import java.util.Set;
  * Provides common email validation rules that can be added to an
  * {@link EmailValidator}.
  */
-public class ValidationRules {
+public final class ValidationRules {
+  private ValidationRules() {}
+
   // Set of reserved TLDs according to RFC 2606, section 2
   // https://datatracker.ietf.org/doc/html/rfc2606
   private static final Set<String> reservedTopLevelDomains = new HashSet<>(

--- a/src/main/java/com/sanctionco/jmail/net/InternetProtocolAddress.java
+++ b/src/main/java/com/sanctionco/jmail/net/InternetProtocolAddress.java
@@ -12,7 +12,9 @@ import java.util.stream.Collectors;
  *
  * <p>Note: IP addresses with prefixes are not currently supported.
  */
-public class InternetProtocolAddress {
+public final class InternetProtocolAddress {
+  private InternetProtocolAddress() {}
+
   private static final String IPV6_PREFIX = "IPv6:";
 
   // Set of allowed characters in a HEX number

--- a/src/main/java/com/sanctionco/jmail/net/InvalidAddressException.java
+++ b/src/main/java/com/sanctionco/jmail/net/InvalidAddressException.java
@@ -4,7 +4,7 @@ package com.sanctionco.jmail.net;
  * A {@link RuntimeException} that indicates an invalid IP address was encountered during
  * validation.
  */
-public class InvalidAddressException extends RuntimeException {
+public final class InvalidAddressException extends RuntimeException {
 
   /**
    * Construct a new instance of {@code InvalidAddressException}.


### PR DESCRIPTION
This is a relatively minor change at this stage in the library's development, but its a change that you can't safely make later on if you have a lot of users.
