### PR TITLE
Add method for caller to get validation failure reason

### DIFF
--- a/src/main/java/com/sanctionco/jmail/EmailValidationResult.java
+++ b/src/main/java/com/sanctionco/jmail/EmailValidationResult.java
@@ -1,0 +1,90 @@
+package com.sanctionco.jmail;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+/**
+ * Contains information about an email address validation, including success or failure,
+ * the parsed email address (if success), and the failure reason (if failure).
+ */
+public final class EmailValidationResult {
+  private final boolean success;
+  private final Email emailAddress;
+  private final FailureReason failureReason;
+
+  EmailValidationResult(boolean success, Email emailAddress, FailureReason failureReason) {
+    this.success = success;
+    this.emailAddress = emailAddress;
+    this.failureReason = failureReason;
+  }
+
+  static EmailValidationResult failure(FailureReason failureReason) {
+    return new EmailValidationResult(false, null, failureReason);
+  }
+
+  static EmailValidationResult success(Email email) {
+    return new EmailValidationResult(true, email, FailureReason.NONE);
+  }
+
+  /**
+   * Return if the email address validation was a success or not.
+   *
+   * @return true if the validation was successful, or false if it was not
+   */
+  public boolean isSuccess() {
+    return success;
+  }
+
+  /**
+   * Return if the email address validation was a failure or not.
+   *
+   * @return true if the validation was not successful, or false if it was
+   */
+  public boolean isFailure() {
+    return !success;
+  }
+
+  /**
+   * Get the parsed {@link Email} object.
+   *
+   * @return the parsed {@link Email} or {@code Optional.empty()} if the validation failed
+   */
+  public Optional<Email> getEmail() {
+    return Optional.ofNullable(emailAddress);
+  }
+
+  /**
+   * Get the reason for failure. If the validation was successful, this method will return
+   * {@code FailureReason.NONE}.
+   *
+   * @return the {@link FailureReason} that describes why the email address failed valiation
+   */
+  public FailureReason getFailureReason() {
+    return failureReason;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", EmailValidationResult.class.getSimpleName() + "[", "]")
+        .add("success=" + success)
+        .add("emailAddress=" + emailAddress)
+        .add("failureReason=" + failureReason)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof EmailValidationResult)) return false;
+    EmailValidationResult that = (EmailValidationResult) o;
+    return Objects.equals(success, that.success)
+        && Objects.equals(emailAddress, that.emailAddress)
+        && Objects.equals(failureReason, that.failureReason);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(success, emailAddress, failureReason);
+  }
+}

--- a/src/main/java/com/sanctionco/jmail/EmailValidator.java
+++ b/src/main/java/com/sanctionco/jmail/EmailValidator.java
@@ -230,6 +230,30 @@ public final class EmailValidator {
   }
 
   /**
+   * Determine if the given email address is valid, returning a new {@link EmailValidationResult}
+   * object that contains details on the result of the validation. Use this method if you need to
+   * see the {@link FailureReason} upon validation failure. See {@link JMail#tryParse(String)}
+   * for details on what is required of an email address within basic validation.
+   *
+   * @param email the email address to validate
+   * @return a {@link EmailValidationResult} containing success or failure, along with the parsed
+   *         {@link Email} object if successful, or the {@link FailureReason} if not
+   */
+  public EmailValidationResult validate(String email) {
+    EmailValidationResult result = JMail.validate(email);
+
+    // If failed basic validation, just return it
+    if (!result.getEmail().isPresent()) return result;
+
+    // If the address fails custom validation, return failure
+    if (!passesPredicates(result.getEmail().get())) {
+      return EmailValidationResult.failure(FailureReason.FAILED_CUSTOM_VALIDATION);
+    }
+
+    return result;
+  }
+
+  /**
    * Attempts to parse the given email address string, only succeeding if the given address is
    * valid according to all registered validation rules. See {@link JMail#tryParse(String)}
    * for details on the basic validation that is always performed.

--- a/src/main/java/com/sanctionco/jmail/FailureReason.java
+++ b/src/main/java/com/sanctionco/jmail/FailureReason.java
@@ -4,12 +4,186 @@ package com.sanctionco.jmail;
  * Enumerates all possible reasons that an email address can fail validation.
  */
 public enum FailureReason {
+
+  /**
+   * An email address cannot be longer than 320 characters.
+   */
   ADDRESS_TOO_LONG,
+
+  /**
+   * An email address cannot be shorter than 3 characters. There must be at least one
+   * character in the local-part, an {@code '@'} symbol, and at least one character
+   * in the domain.
+   */
   ADDRESS_TOO_SHORT,
+
+  /**
+   * An email address cannot begin with the {@code '@'} symbol, unless it has valid source
+   * routing at the start of the address.
+   */
   BEGINS_WITH_AT_SYMBOL,
+
+  /**
+   * Certain characters are not allowed to appear within the local-part of an email address
+   * unless they are quoted. The set of characters that are not allowed outside of quotes is:
+   * {@code '\t', '(', ')', ',', ':', ';', '<', '>', '@', '[', ']', '"'}.
+   */
+  DISALLOWED_UNQUOTED_CHARACTER,
+
+  /**
+   * An email address must contain a domain.
+   */
+  DOMAIN_MISSING,
+
+  /**
+   * Any single domain part (separated by dots) of am email address cannot end with the
+   * {@code '-'} character.
+   */
+  DOMAIN_PART_ENDS_WITH_DASH,
+
+  /**
+   * Any single domain part (separated by dots) of am email address cannot start with the
+   * {@code '-'} character.
+   */
+  DOMAIN_PART_STARTS_WITH_DASH,
+
+  /**
+   * Any single domain part (separated by dots) of am email address cannot be more than
+   * 63 characters.
+   */
+  DOMAIN_PART_TOO_LONG,
+
+  /**
+   * The domain of an email address cannot start with the {@code '.'} character.
+   */
+  DOMAIN_STARTS_WITH_DOT,
+
+  /**
+   * The domain of an email address cannot be more than 255 characters.
+   */
+  DOMAIN_TOO_LONG,
+
+  /**
+   * An email address cannot end with the {@code '.'} character.
+   */
   ENDS_WITH_DOT,
+
+  /**
+   * A comment within an email address should have surrounding parenthesis. If it does not,
+   * for example there is no closing parenthesis, then the email address is invalid.
+   */
+  INVALID_COMMENT,
+
+  /**
+   * A comment within an email address should be dot-separated from other parts of the address.
+   */
+  INVALID_COMMENT_LOCATION,
+
+  /**
+   * The domain of an email address can only contain alphanumeric characters, as well as the
+   * characters {@code '.', '-'} and whitespace. This failure reason indicates that a character
+   * was found in the domain that is not allowed.
+   */
+  INVALID_DOMAIN_CHARACTER,
+
+  /**
+   * An email address can use an IP address for the domain. The IP address must be in the format
+   * {@code [IPV4_addr]} or {@code [IPV6_addr]}. This failure reason indicates that the address
+   * attempted to use an IP address domain, but it has either an invalid format or an
+   * invalid IP address.
+   */
+  INVALID_IP_DOMAIN,
+
+  /**
+   * Quoted parts within an email address must be dot-separated from other parts of the address.
+   */
+  INVALID_QUOTE_LOCATION,
+
+  /**
+   * Whitespace is only allowed in an email address if it is between parts or the address has
+   * an identifier.
+   */
+  INVALID_WHITESPACE,
+
+  /**
+   * The local-part of an email address cannot end with the {@code '.'} character.
+   */
+  LOCAL_PART_ENDS_WITH_DOT,
+
+  /**
+   * An email address must contain a local-part of at least one character.
+   */
+  LOCAL_PART_MISSING,
+
+  /**
+   * The local-part of an email address cannot be more than 64 characters.
+   */
+  LOCAL_PART_TOO_LONG,
+
+  /**
+   * An email address must contain the at {@code '@'} symbol exactly once.
+   */
+  MISSING_AT_SYMBOL,
+
+  /**
+   * The characters {@code '\r', '␀', '\n'} are allowed within quotes only if they are escaped
+   * with a backslash. This failure reason indicates that the backslash was missing in the address.
+   */
+  MISSING_BACKSLASH_ESCAPE,
+
+  /**
+   * An email address must contain a top level domain, the final part of the domain.
+   *
+   * @see TopLevelDomain
+   */
+  MISSING_TOP_LEVEL_DOMAIN,
+
+  /**
+   * An email address can only have a single unquoted {@code '@'} symbol. Multiple
+   * {@code '@'} symbols can only appear within quoted parts, or escaped with a preceding
+   * {@code '\'} character.
+   */
   MULTIPLE_AT_SYMBOLS,
+
+  /**
+   * An email address cannot have two consecutive dot {@code '.'} characters outside of quotes.
+   */
+  MULTIPLE_DOT_SEPARATORS,
+
+  /**
+   * Indicates no validation failure.
+   */
   NONE,
+
+  /**
+   * An email address cannot be {@code null}.
+   */
   NULL_ADDRESS,
-  STARTS_WITH_DOT
+
+  /**
+   * The TLD of an email address cannot be all numeric (ex: {@code test@hello.123}).
+   */
+  NUMERIC_TLD,
+
+  /**
+   * An email address cannot start with the {@code '.'} character.
+   */
+  STARTS_WITH_DOT,
+
+  /**
+   * The top level domain of an email address cannot be more than 63 characters.
+   */
+  TOP_LEVEL_DOMAIN_TOO_LONG,
+
+  /**
+   * An email address cannot contain the {@code '<'} character outside of quotes,
+   * unless the address has an identifier.
+   */
+  UNQUOTED_ANGLED_BRACKET,
+
+  /**
+   * A backslash {@code '\'} within the local-part of an email address must be used to escape
+   * a character, it cannot exist on its own.
+   */
+  UNUSED_BACKSLASH_ESCAPE,
 }

--- a/src/main/java/com/sanctionco/jmail/FailureReason.java
+++ b/src/main/java/com/sanctionco/jmail/FailureReason.java
@@ -54,11 +54,6 @@ public enum FailureReason {
   DOMAIN_PART_TOO_LONG,
 
   /**
-   * The domain of an email address cannot start with the {@code '.'} character.
-   */
-  DOMAIN_STARTS_WITH_DOT,
-
-  /**
    * The domain of an email address cannot be more than 255 characters.
    */
   DOMAIN_TOO_LONG,

--- a/src/main/java/com/sanctionco/jmail/FailureReason.java
+++ b/src/main/java/com/sanctionco/jmail/FailureReason.java
@@ -64,6 +64,12 @@ public enum FailureReason {
   ENDS_WITH_DOT,
 
   /**
+   * If an email address fails custom validation that was added to an {@link EmailValidator},
+   * then this failure reason indicates that the email address failed custom validation.
+   */
+  FAILED_CUSTOM_VALIDATION,
+
+  /**
    * A comment within an email address should have surrounding parenthesis. If it does not,
    * for example there is no closing parenthesis, then the email address is invalid.
    */

--- a/src/main/java/com/sanctionco/jmail/FailureReason.java
+++ b/src/main/java/com/sanctionco/jmail/FailureReason.java
@@ -1,0 +1,15 @@
+package com.sanctionco.jmail;
+
+/**
+ * Enumerates all possible reasons that an email address can fail validation.
+ */
+public enum FailureReason {
+  ADDRESS_TOO_LONG,
+  ADDRESS_TOO_SHORT,
+  BEGINS_WITH_AT_SYMBOL,
+  ENDS_WITH_DOT,
+  MULTIPLE_AT_SYMBOLS,
+  NONE,
+  NULL_ADDRESS,
+  STARTS_WITH_DOT
+}

--- a/src/main/java/com/sanctionco/jmail/JMail.java
+++ b/src/main/java/com/sanctionco/jmail/JMail.java
@@ -378,10 +378,6 @@ public final class JMail {
         }
 
         if (c == '.') {
-          if (currentDomainPart.length() == 0) {
-            return EmailValidationResult.failure(FailureReason.DOMAIN_STARTS_WITH_DOT);
-          }
-
           if (currentDomainPart.length() > 63) {
             return EmailValidationResult.failure(FailureReason.DOMAIN_PART_TOO_LONG);
           }
@@ -486,6 +482,7 @@ public final class JMail {
     StringBuilder builder = new StringBuilder(s.length());
 
     boolean previousBackslash = false;
+    boolean foundClosingParenthesis = false;
 
     for (int i = 0, size = s.length(); i < size; i++) {
       char c = s.charAt(i);
@@ -504,10 +501,15 @@ public final class JMail {
       builder.append(c);
 
       if (c == ')' && !previousBackslash) {
+        foundClosingParenthesis = true;
         break;
       }
 
       previousBackslash = c == '\\';
+    }
+
+    if (!foundClosingParenthesis) {
+      return Optional.empty();
     }
 
     return Optional.of(builder.toString());

--- a/src/main/java/com/sanctionco/jmail/JMail.java
+++ b/src/main/java/com/sanctionco/jmail/JMail.java
@@ -94,6 +94,20 @@ public final class JMail {
   }
 
   /**
+   * Determine if the given email address is valid, returning a new {@link EmailValidationResult}
+   * object that contains details on the result of the validation. Use this method if you need to
+   * see the {@link FailureReason} upon validation failure. See {@link #tryParse(String)}
+   * for details on what is required of an email address within basic validation.
+   *
+   * @param email the email address to validate
+   * @return a {@link EmailValidationResult} containing success or failure, along with the parsed
+   *         {@link Email} object if successful, or the {@link FailureReason} if not
+   */
+  public static EmailValidationResult validate(String email) {
+    return validateInternal(email);
+  }
+
+  /**
    * Parse the given email address into a new {@link Email} object. This method does basic
    * validation on the input email address. This method does not claim to be 100%
    * accurate in determining if an email address is valid or invalid due to the
@@ -109,7 +123,7 @@ public final class JMail {
    *         is invalid
    */
   public static Optional<Email> tryParse(String email) {
-    EmailValidationResult result = internalTryParse(email);
+    EmailValidationResult result = validateInternal(email);
 
     return result.getEmail();
   }
@@ -120,7 +134,7 @@ public final class JMail {
    * @param email the email address to parse
    * @return a new {@link Email} instance if valid, empty if invalid
    */
-  private static EmailValidationResult internalTryParse(String email) {
+  private static EmailValidationResult validateInternal(String email) {
     // email cannot be null
     if (email == null) return EmailValidationResult.failure(FailureReason.NULL_ADDRESS);
 
@@ -195,7 +209,7 @@ public final class JMail {
           return EmailValidationResult.failure(FailureReason.UNQUOTED_ANGLED_BRACKET);
         }
 
-        EmailValidationResult innerResult = internalTryParse(email.substring(i + 1, size - 1));
+        EmailValidationResult innerResult = validateInternal(email.substring(i + 1, size - 1));
 
         // If the address passed validation, return success with the identifier included
         if (innerResult.getEmail().isPresent()) {

--- a/src/main/java/com/sanctionco/jmail/JMail.java
+++ b/src/main/java/com/sanctionco/jmail/JMail.java
@@ -139,10 +139,12 @@ public final class JMail {
     if (email.charAt(0) == '@') {
       Optional<SourceRouteDetail> sourceRoute = validateSourceRouting(email);
 
-      // If there was no source routing, then starting with @ is invalid
+      // If the sourceRoute is not present, then either the route was invalid or there was no
+      // source routing.
+      // If there was no source routing then starting with @ is invalid
       if (!sourceRoute.isPresent()) return Optional.empty();
 
-      // Otherwise update the email to validate to be just the actual email
+      // Otherwise, update the email to validate to be just the actual email
       SourceRouteDetail detail = sourceRoute.get();
       sourceRoutes = detail.routes;
       fullSourceRoute = detail.fullRoute.toString();
@@ -190,7 +192,7 @@ public final class JMail {
       char c = email.charAt(i);
 
       if (c == '<' && !inQuotes && !previousBackslash) {
-        // could be phrase <address> format. If not, it's not allowed
+        // could be "phrase <address>" format. If not, it's not allowed
         if (!(email.charAt(size - 1) == '>')) return Optional.empty();
 
         return tryParse(email.substring(i + 1, size - 1))

--- a/src/main/java/com/sanctionco/jmail/JMail.java
+++ b/src/main/java/com/sanctionco/jmail/JMail.java
@@ -423,10 +423,6 @@ public final class JMail {
 
     if (!atFound) return EmailValidationResult.failure(FailureReason.MISSING_AT_SYMBOL);
 
-    if (requireAtDotOrComment) {
-      return EmailValidationResult.failure(FailureReason.INVALID_QUOTE_LOCATION);
-    }
-
     // Check length
     int localPartLen = localPart.length() - localPartCommentLength;
     if (localPartLen == 0) return EmailValidationResult.failure(FailureReason.LOCAL_PART_MISSING);

--- a/src/test/java/com/sanctionco/jmail/EmailValidationResultTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailValidationResultTest.java
@@ -32,6 +32,8 @@ class EmailValidationResultTest {
         .returns(false, EmailValidationResult::isSuccess)
         .returns(true, EmailValidationResult::isFailure)
         .returns(Optional.empty(), EmailValidationResult::getEmail)
-        .returns(FailureReason.NULL_ADDRESS, EmailValidationResult::getFailureReason);
+        .returns(FailureReason.NULL_ADDRESS, EmailValidationResult::getFailureReason)
+        .hasToString("EmailValidationResult"
+            + "[success=false, emailAddress=null, failureReason=NULL_ADDRESS]");
   }
 }

--- a/src/test/java/com/sanctionco/jmail/EmailValidationResultTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailValidationResultTest.java
@@ -1,0 +1,35 @@
+package com.sanctionco.jmail;
+
+import java.util.Optional;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmailValidationResultTest {
+
+  @Test
+  void ensureEqualsContract() {
+    EqualsVerifier.forClass(EmailValidationResult.class).verify();
+  }
+
+  @Test
+  void testStaticSuccessConstructor() {
+    Optional<Email> testEmail = Email.of("test@test.com");
+
+    assertThat(EmailValidationResult.success(testEmail.get()))
+        .returns(true, EmailValidationResult::isSuccess)
+        .returns(testEmail, EmailValidationResult::getEmail)
+        .returns(FailureReason.NONE, EmailValidationResult::getFailureReason);
+  }
+
+  @Test
+  void testStaticFailureConstructor() {
+    assertThat(EmailValidationResult.failure(FailureReason.NULL_ADDRESS))
+        .returns(true, EmailValidationResult::isFailure)
+        .returns(Optional.empty(), EmailValidationResult::getEmail)
+        .returns(FailureReason.NULL_ADDRESS, EmailValidationResult::getFailureReason);
+  }
+}

--- a/src/test/java/com/sanctionco/jmail/EmailValidationResultTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailValidationResultTest.java
@@ -21,6 +21,7 @@ class EmailValidationResultTest {
 
     assertThat(EmailValidationResult.success(testEmail.get()))
         .returns(true, EmailValidationResult::isSuccess)
+        .returns(false, EmailValidationResult::isFailure)
         .returns(testEmail, EmailValidationResult::getEmail)
         .returns(FailureReason.NONE, EmailValidationResult::getFailureReason);
   }
@@ -28,6 +29,7 @@ class EmailValidationResultTest {
   @Test
   void testStaticFailureConstructor() {
     assertThat(EmailValidationResult.failure(FailureReason.NULL_ADDRESS))
+        .returns(false, EmailValidationResult::isSuccess)
         .returns(true, EmailValidationResult::isFailure)
         .returns(Optional.empty(), EmailValidationResult::getEmail)
         .returns(FailureReason.NULL_ADDRESS, EmailValidationResult::getFailureReason);

--- a/src/test/java/com/sanctionco/jmail/EmailValidatorTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailValidatorTest.java
@@ -74,7 +74,7 @@ class EmailValidatorTest {
   @Nested
   class RequireTopLevelDomain {
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"admin@mailserver1", "test@example", "test@-server"})
+    @ValueSource(strings = {"admin@mailserver1", "test@example", "test@server"})
     void rejectsDotlessAddresses(String email) {
       runInvalidTest(JMail.validator().requireTopLevelDomain(), email);
     }
@@ -104,7 +104,7 @@ class EmailValidatorTest {
   @Nested
   class DisallowQuotedIdentifiers {
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"John Smith <test@server.com>", "ABC <123t@abc.net"})
+    @ValueSource(strings = {"John Smith <test@server.com>", "ABC <123t@abc.net>"})
     void rejectsAddressesWithQuotedIdentifiers(String email) {
       runInvalidTest(JMail.validator().disallowQuotedIdentifiers(), email);
     }
@@ -200,6 +200,7 @@ class EmailValidatorTest {
     assertThat(validator.tryParse(email)).isPresent();
     assertThat(email).is(valid);
     assertThatNoException().isThrownBy(() -> validator.enforceValid(email));
+    assertThat(validator.validate(email).isSuccess()).isTrue();
   }
 
   private static void runInvalidTest(EmailValidator validator, String email) {
@@ -209,5 +210,8 @@ class EmailValidatorTest {
     assertThat(email).is(invalid);
     assertThatExceptionOfType(InvalidEmailException.class)
         .isThrownBy(() -> validator.enforceValid(email));
+    assertThat(validator.validate(email).isFailure()).isTrue();
+    assertThat(validator.validate(email).getFailureReason())
+        .isEqualTo(FailureReason.FAILED_CUSTOM_VALIDATION);
   }
 }

--- a/src/test/java/com/sanctionco/jmail/EmailValidatorTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailValidatorTest.java
@@ -26,6 +26,16 @@ class EmailValidatorTest {
   }
 
   @Test
+  void passesThroughDefaultValidateFailure() {
+    String invalid = "test.@test.com";
+
+    EmailValidationResult result = JMail.validator().validate(invalid);
+
+    assertThat(result.isFailure()).isTrue();
+    assertThat(result.getFailureReason()).isEqualTo(FailureReason.LOCAL_PART_ENDS_WITH_DOT);
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   void duplicateRuleCallsOnlyAddsOnePredicate() throws Exception {
     EmailValidator validator = JMail.validator()

--- a/src/test/java/com/sanctionco/jmail/FailureReasonTest.java
+++ b/src/test/java/com/sanctionco/jmail/FailureReasonTest.java
@@ -1,0 +1,62 @@
+package com.sanctionco.jmail;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FailureReasonTest {
+
+  public static Stream<Arguments> provideTestEmails() {
+    return Stream.of(
+        Arguments.of("A@", FailureReason.ADDRESS_TOO_SHORT),
+        Arguments.of("@my.test.com", FailureReason.BEGINS_WITH_AT_SYMBOL),
+        Arguments.of("te[st@test.com", FailureReason.DISALLOWED_UNQUOTED_CHARACTER),
+        Arguments.of("test@", FailureReason.DOMAIN_MISSING),
+        Arguments.of("test@test-.com", FailureReason.DOMAIN_PART_ENDS_WITH_DASH),
+        Arguments.of("test@my.-test.com", FailureReason.DOMAIN_PART_STARTS_WITH_DASH),
+        Arguments.of(
+            "first.last@x234567890123456789012345678901234567890123456789012345678901234.test.org",
+            FailureReason.DOMAIN_PART_TOO_LONG),
+        Arguments.of("x@x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
+            + "x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
+            + "x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789."
+            + "x23456789.x23456789.x23456", FailureReason.DOMAIN_TOO_LONG),
+        Arguments.of("test@test.", FailureReason.ENDS_WITH_DOT),
+        Arguments.of("test@test.com(i", FailureReason.INVALID_COMMENT),
+        Arguments.of("test(comment)hey@test.com", FailureReason.INVALID_COMMENT_LOCATION),
+        Arguments.of("user@my_example.com", FailureReason.INVALID_DOMAIN_CHARACTER),
+        Arguments.of("test@[1.2]", FailureReason.INVALID_IP_DOMAIN),
+        Arguments.of("just\"not\"right@example.com", FailureReason.INVALID_QUOTE_LOCATION),
+        Arguments.of("this isnotallowed@example.com", FailureReason.INVALID_WHITESPACE),
+        Arguments.of("test.@test.com", FailureReason.LOCAL_PART_ENDS_WITH_DOT),
+        Arguments.of("()@test.com", FailureReason.LOCAL_PART_MISSING),
+        Arguments.of(
+            "1234567890123456789012345678901234567890123456789012345678901234+x@e.com",
+            FailureReason.LOCAL_PART_TOO_LONG),
+        Arguments.of("Abc.example.com", FailureReason.MISSING_AT_SYMBOL),
+        Arguments.of("\"test\rblah\"@test.org", FailureReason.MISSING_BACKSLASH_ESCAPE),
+        Arguments.of("test@test.(comment)", FailureReason.MISSING_TOP_LEVEL_DOMAIN),
+        Arguments.of("A@b@c@example.com", FailureReason.MULTIPLE_AT_SYMBOLS),
+        Arguments.of("test..mytest@test.com", FailureReason.MULTIPLE_DOT_SEPARATORS),
+        Arguments.of(null, FailureReason.NULL_ADDRESS),
+        Arguments.of("test@test.123", FailureReason.NUMERIC_TLD),
+        Arguments.of(".test@test.com", FailureReason.STARTS_WITH_DOT),
+        Arguments.of("test@really.long.topleveldomainisnotallowedunfortunatelyforpeople"
+            + "wholikereallylongtopleveldomainnames", FailureReason.TOP_LEVEL_DOMAIN_TOO_LONG),
+        Arguments.of("te<st@test.com", FailureReason.UNQUOTED_ANGLED_BRACKET),
+        Arguments.of("te\\st@test.com", FailureReason.UNUSED_BACKSLASH_ESCAPE));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideTestEmails")
+  void ensureFailureReasonsMatch(String email, FailureReason failureReason) {
+    EmailValidationResult result = JMail.validate(email);
+
+    assertThat(result.isFailure()).isTrue();
+    assertThat(result.getFailureReason()).isEqualTo(failureReason);
+  }
+}

--- a/src/test/java/com/sanctionco/jmail/JMailTest.java
+++ b/src/test/java/com/sanctionco/jmail/JMailTest.java
@@ -52,6 +52,8 @@ class JMailTest {
         .returns(expectedParts, Email::domainParts)
         .returns(expectedTld, Email::topLevelDomain);
 
+    assertThat(JMail.validate(email).isSuccess()).isTrue();
+
     assertThat(email).is(valid);
     assertThatNoException().isThrownBy(() -> JMail.enforceValid(email));
   }
@@ -97,6 +99,8 @@ class JMailTest {
   @CsvFileSource(resources = "/invalid-addresses.csv", delimiterString = " ;", numLinesToSkip = 1)
   void ensureInvalidFails(String email) {
     assertThat(JMail.tryParse(email)).isNotPresent();
+
+    assertThat(JMail.validate(email).isFailure()).isTrue();
 
     assertThat(email).is(invalid);
     assertThatExceptionOfType(InvalidEmailException.class)

--- a/src/test/java/com/sanctionco/jmail/TopLevelDomainTest.java
+++ b/src/test/java/com/sanctionco/jmail/TopLevelDomainTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 @SuppressWarnings("JUnit5MalformedParameterized")
 class TopLevelDomainTest {
 
-  @SuppressWarnings("unused")
-  Stream<Arguments> provideArgs() {
+  static Stream<Arguments> provideArgs() {
     return Stream.of(
         TopLevelDomain.DOT_COM,
         TopLevelDomain.DOT_EDU,

--- a/src/test/resources/invalid-addresses.csv
+++ b/src/test/resources/invalid-addresses.csv
@@ -109,6 +109,7 @@ test..test@test.org ;                                                           
 test@test@test.org ;                                                                   There cannot be more than one @ character
 test@@test.org ;                                                                       There cannot be more than one @ character
 -- test --@test.org ;                                                                  Whitespace must be separated by . characters
+test@te st.org ;                                                                       Whitespace must be separated by . characters
 [test]@test.org ;                                                                      The characters [ and ] are not allowed unquoted
 "test"test"@test.org ;                                                                 Quotes must be in pairs
 ()[]\;:,><@test.org ;                                                                  The local-part contains invalid unquoted characters

--- a/src/test/resources/invalid-addresses.csv
+++ b/src/test/resources/invalid-addresses.csv
@@ -139,3 +139,4 @@ Joe A Smith <email@example.com-> ;                                              
 Joe A Smith <email@-example.com-> ;                                                    The address part must be valid (domain cannot start with a dash)
 Joe A Smith <email> ;                                                                  The address part must be valid (missing @ character and domain)
 ABC.DEF@GHI. (MNO) ;                                                                   The domain cannot end with the . character even with an ending comment
+test@test.com(comment ;                                                                A comment at the end of the domain must have closing parenthesis


### PR DESCRIPTION
This PR contains:

- A new `validate(String email)` method both within `JMail` and `EmailValidator`. The method returns an `EmailValidationResult` containing the details of the validation result.
- Enumerate all of the possible reasons an email address could fail validation within the `FailureReason` enum.
- Fix a bug where email address with a comment at the end of the domain that was missing the closing parenthesis (ex: `test@test.com(comment`) would incorrectly validate