### PR TITLE
Add rule to require only ASCII characters in an address

### DIFF
--- a/src/main/java/com/sanctionco/jmail/EmailValidator.java
+++ b/src/main/java/com/sanctionco/jmail/EmailValidator.java
@@ -44,6 +44,8 @@ public final class EmailValidator {
       = ValidationRules::disallowObsoleteWhitespace;
   private static final Predicate<Email> REQUIRE_VALID_MX_RECORD_PREDICATE
       = ValidationRules::requireValidMXRecord;
+  private static final Predicate<Email> REQUIRE_ONLY_ASCII_CHARACTERS_PREDICATE
+      = ValidationRules::requireOnlyAscii;
 
   private final Set<Predicate<Email>> validationPredicates;
 
@@ -224,6 +226,20 @@ public final class EmailValidator {
   public EmailValidator requireValidMXRecord(int initialTimeout, int numRetries) {
     return withRule(email ->
         ValidationRules.requireValidMXRecord(email, initialTimeout, numRetries));
+  }
+
+  /**
+   * Create a new {@code EmailValidator} with all rules from the current instance and the
+   * {@link ValidationRules#requireOnlyAscii(Email)} rule.
+   * Email addresses that contain characters other than those in the ASCII charset will fail
+   * validation.
+   *
+   * <p>For example, {@code "jørn@test.com"} would be invalid.
+   *
+   * @return the new {@code EmailValidator} instance
+   */
+  public EmailValidator requireOnlyAsciiCharacters() {
+    return withRule(REQUIRE_ONLY_ASCII_CHARACTERS_PREDICATE);
   }
 
   /**

--- a/src/main/java/com/sanctionco/jmail/ValidationRules.java
+++ b/src/main/java/com/sanctionco/jmail/ValidationRules.java
@@ -160,4 +160,14 @@ public final class ValidationRules {
   public static boolean requireValidMXRecord(Email email, int initialTimeout, int numRetries) {
     return DNSLookupUtil.hasMXRecord(email.domainWithoutComments(), initialTimeout, numRetries);
   }
+
+  /**
+   * Rejects an email address that contains characters other than those in the ASCII set.
+   *
+   * @param email the email address to validate
+   * @return true if this email address only contains ASCII characters, or false if it does not
+   */
+  public static boolean requireOnlyAscii(Email email) {
+    return email.toString().chars().allMatch(c -> c < 128);
+  }
 }

--- a/src/test/java/com/sanctionco/jmail/EmailValidatorTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailValidatorTest.java
@@ -210,6 +210,24 @@ class EmailValidatorTest {
   }
 
   @Nested
+  class RequireOnlyAsciiCharacters {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {
+        "jørn@test.com", "我買@屋企.香港", "Pelé@example.com", "xyz@🙏.kz"})
+    void rejectsNonAsciiEmails(String email) {
+      runInvalidTest(JMail.validator().requireOnlyAsciiCharacters(), email);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {
+        "test@domain.test.org", "hello@world", "user%uucp!path@berkeley.edu",
+        "\"John Michael\" <tester@test.net>", "(comment)test@test.org"})
+    void allowsOtherAddresses(String email) {
+      runValidTest(JMail.validator().requireOnlyAsciiCharacters(), email);
+    }
+  }
+
+  @Nested
   class CustomRule {
     @ParameterizedTest(name = "{0}")
     @ValueSource(strings = {"first.last@test.com", "x@test.two.com"})


### PR DESCRIPTION
As requested in #167