### PR TITLE
feat: add convertDomainToAscii normalization option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # JMail Changelog
 
+## 2.2.0
+
+- Add new normalization option `convertDomainToAscii()`, to have internationalized domain names (IDNs) be converted to ASCII during normalization (Thanks @JamesBoon for suggesting!).
+
+---
 ## 2.1.0
 
 - Fix bug where addresses containing unquoted Unicode punctuation or symbol characters in the local-part would be incorrectly considered valid (Thanks @acmcmurray for reporting and @houssam966 for contributing! 🎉).

--- a/src/main/java/com/sanctionco/jmail/Email.java
+++ b/src/main/java/com/sanctionco/jmail/Email.java
@@ -1,6 +1,7 @@
 package com.sanctionco.jmail;
 
 import com.sanctionco.jmail.normalization.CaseOption;
+import com.sanctionco.jmail.normalization.IDNConverter;
 import com.sanctionco.jmail.normalization.NormalizationOptions;
 
 import java.nio.charset.StandardCharsets;
@@ -435,11 +436,16 @@ public final class Email {
   }
 
   private String normalizedDomain(NormalizationOptions options) {
-    CaseOption caseOption = options.getCaseOption();
+    if (isIpAddress) {
+      return "[" + this.domainWithoutComments + "]";
+    }
 
-    return isIpAddress
-        ? "[" + this.domainWithoutComments + "]"
-        : caseOption.adjustDomain(this.domainWithoutComments);
+    String domain = options.shouldConvertDomainToAscii() && !isAscii
+        ? IDNConverter.labelsToAsciiDomain(this.domainParts)
+        : this.domainWithoutComments;
+
+    CaseOption caseOption = options.getCaseOption();
+    return caseOption.adjustDomain(domain);
   }
 
   private String toHexString(byte[] bytes) {

--- a/src/main/java/com/sanctionco/jmail/normalization/IDNConverter.java
+++ b/src/main/java/com/sanctionco/jmail/normalization/IDNConverter.java
@@ -18,6 +18,9 @@ public class IDNConverter {
   private static final int INITIAL_BIAS = 72;
   private static final int INITIAL_N = 0x80;
 
+  private IDNConverter() {
+  }
+
   /**
    * Convert a list of labels to ASCII-compatible format, and join them into a domain name.
    * Handles internationalized domain labels.
@@ -57,12 +60,7 @@ public class IDNConverter {
     }
 
     // Encode to Punycode
-    try {
-      return ACE_PREFIX + punycodeEncode(label);
-    } catch (Exception e) {
-      // If encoding fails, return original lowercase
-      return label;
-    }
+    return ACE_PREFIX + punycodeEncode(label);
   }
 
   /**

--- a/src/main/java/com/sanctionco/jmail/normalization/IDNConverter.java
+++ b/src/main/java/com/sanctionco/jmail/normalization/IDNConverter.java
@@ -1,0 +1,190 @@
+package com.sanctionco.jmail.normalization;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Contains static utility methods for converting internationalized
+ * domain names (IDN) to ASCII using Punycode.
+ */
+public class IDNConverter {
+  private static final String ACE_PREFIX = "xn--";
+  private static final int BASE = 36;
+  private static final int TMIN = 1;
+  private static final int TMAX = 26;
+  private static final int SKEW = 38;
+  private static final int DAMP = 700;
+  private static final int INITIAL_BIAS = 72;
+  private static final int INITIAL_N = 0x80;
+
+  /**
+   * Convert a list of labels to ASCII-compatible format, and join them into a domain name.
+   * Handles internationalized domain labels.
+   *
+   * <p>Any labels that are {@code null} will be dropped and excluded from the result.
+   *
+   * @param labels the list of labels to convert like {@code [münchen, co, uk]}
+   * @return ASCII domain like {@code xn--mnchen-3ya.co.uk"}
+   */
+  public static String labelsToAsciiDomain(List<String> labels) {
+    if (labels == null || labels.isEmpty()) {
+      return "";
+    }
+
+    return labels.stream()
+        .filter(Objects::nonNull)
+        .map(IDNConverter::labelToASCII)
+        .collect(Collectors.joining("."));
+  }
+
+  /**
+   * Convert a single domain label to ASCII using Punycode.
+   *
+   * @param label Single label like "münchen"
+   * @return ASCII label like "xn--mnchen-3ya"
+   */
+  private static String labelToASCII(String label) {
+    if (label.isEmpty()) {
+      return label;
+    }
+
+    label = label.toLowerCase();
+
+    // Check if already ASCII. If so, just return the lowercased version
+    if (isASCII(label)) {
+      return label;
+    }
+
+    // Encode to Punycode
+    try {
+      return ACE_PREFIX + punycodeEncode(label);
+    } catch (Exception e) {
+      // If encoding fails, return original lowercase
+      return label;
+    }
+  }
+
+  /**
+   * Encode a Unicode string to Punycode.
+   *
+   * @param input Unicode string
+   * @return Punycode string (without "xn--" prefix)
+   */
+  private static String punycodeEncode(String input) {
+    StringBuilder output = new StringBuilder();
+    int[] codePoints = input.codePoints().toArray();
+    int n = INITIAL_N;
+    int bias = INITIAL_BIAS;
+    int delta = 0;
+    int basicCount = 0;
+
+    // First, add all ASCII characters
+    for (int cp : codePoints) {
+      if (cp < 128) {
+        output.append((char) cp);
+        basicCount++;
+      }
+    }
+
+    if (basicCount > 0) {
+      output.append('-');
+    }
+
+    int handledCount = basicCount;
+
+    while (handledCount < codePoints.length) {
+      int nextCodePoint = Integer.MAX_VALUE;
+
+      // Find the next smallest code point >= n
+      for (int cp : codePoints) {
+        if (cp >= n && cp < nextCodePoint) {
+          nextCodePoint = cp;
+        }
+      }
+
+      delta += (nextCodePoint - n) * (handledCount + 1);
+      n = nextCodePoint;
+
+      for (int cp : codePoints) {
+        if (cp < n) {
+          delta++;
+        } else if (cp == n) {
+          // Encode delta as variable-length integer
+          int q = delta;
+          for (int k = BASE; ; k += BASE) {
+            int t;
+            if (k <= bias) {
+              t = TMIN;
+            } else if (k >= bias + TMAX) {
+              t = TMAX;
+            } else {
+              t = k - bias;
+            }
+
+            if (q < t) {
+              break;
+            }
+
+            output.append(digitToBasic(t + (q - t) % (BASE - t)));
+            q = (q - t) / (BASE - t);
+          }
+
+          output.append(digitToBasic(q));
+          bias = adaptBias(delta, handledCount + 1, handledCount == basicCount);
+          delta = 0;
+          handledCount++;
+        }
+      }
+
+      delta++;
+      n++;
+    }
+
+    return output.toString();
+  }
+
+  /**
+   * Encode a digit as a basic code point.
+   */
+  private static char digitToBasic(int digit) {
+    if (digit < 26) {
+      return (char) ('a' + digit);
+    } else {
+      return (char) ('0' + digit - 26);
+    }
+  }
+
+  /**
+   * Adapt bias according to Punycode algorithm.
+   */
+  private static int adaptBias(int delta, int length, boolean firstTime) {
+    if (firstTime) {
+      delta /= DAMP;
+    } else {
+      delta /= 2;
+    }
+
+    delta += delta / length;
+
+    int k = 0;
+    while (delta > ((BASE - TMIN) * TMAX) / 2) {
+      delta /= (BASE - TMIN);
+      k += BASE;
+    }
+
+    return k + (((BASE - TMIN + 1) * delta) / (delta + SKEW));
+  }
+
+  /**
+   * Check if a string contains only ASCII characters.
+   */
+  private static boolean isASCII(String str) {
+    for (char c : str.toCharArray()) {
+      if (c > 127) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/sanctionco/jmail/normalization/NormalizationOptions.java
+++ b/src/main/java/com/sanctionco/jmail/normalization/NormalizationOptions.java
@@ -25,6 +25,7 @@ public class NormalizationOptions {
   private final String subAddressSeparator;
   private final boolean performUnicodeNormalization;
   private final Normalizer.Form unicodeNormalizationForm;
+  private final boolean convertDomainToAscii;
 
   NormalizationOptions(NormalizationOptionsBuilder builder) {
     this.caseOption = builder.caseOption;
@@ -34,6 +35,7 @@ public class NormalizationOptions {
     this.subAddressSeparator = builder.subAddressSeparator;
     this.performUnicodeNormalization = builder.performUnicodeNormalization;
     this.unicodeNormalizationForm = builder.unicodeNormalizationForm;
+    this.convertDomainToAscii = builder.convertDomainToAscii;
   }
 
   /**
@@ -116,6 +118,17 @@ public class NormalizationOptions {
    */
   public Normalizer.Form getUnicodeNormalizationForm() {
     return unicodeNormalizationForm;
+  }
+
+  /**
+   * <p>Whether to convert the domain of the email address to ASCII using Punycode encoding.</p>
+   *
+   * <p>By default, this is {@code false}.</p>
+   *
+   * @return true if the domain should be converted to ASCII, or false otherwise
+   */
+  public boolean shouldConvertDomainToAscii() {
+    return convertDomainToAscii;
   }
 
   /**

--- a/src/main/java/com/sanctionco/jmail/normalization/NormalizationOptionsBuilder.java
+++ b/src/main/java/com/sanctionco/jmail/normalization/NormalizationOptionsBuilder.java
@@ -15,6 +15,7 @@ public class NormalizationOptionsBuilder {
   String subAddressSeparator = "+";
   boolean performUnicodeNormalization = false;
   Normalizer.Form unicodeNormalizationForm = Normalizer.Form.NFKC;
+  boolean convertDomainToAscii = false;
 
   NormalizationOptionsBuilder() {
   }
@@ -166,6 +167,28 @@ public class NormalizationOptionsBuilder {
   public NormalizationOptionsBuilder performUnicodeNormalization(Normalizer.Form form) {
     this.performUnicodeNormalization = true;
     this.unicodeNormalizationForm = form;
+    return this;
+  }
+
+  /**
+   * <p>Convert the domain of the email address to ASCII.</p>
+   *
+   * <p>Although most modern mail servers support IDNs (internationalized domain names), there
+   * may be some legacy servers that do not. Therefore, it may be beneficial in some situations
+   * to be able to normalize the domain of the email address to its ASCII form. Enabling
+   * this conversion will ensure that any non-ASCII domain parts are turned into ASCII
+   * via Punycode encoding, as specified in
+   * <a href="https://datatracker.ietf.org/doc/html/rfc3492">RFC 3492</a>.</p>
+   *
+   * <p><strong>Note:</strong> enabling this option also results in the domain being lowercased,
+   * as that is required as part of the encoding algorithm.</p>
+   *
+   * <p>The default normalization behavior does <strong>not</strong> convert domains to ASCII.</p>
+   *
+   * @return this
+   */
+  public NormalizationOptionsBuilder convertDomainToAscii() {
+    this.convertDomainToAscii = true;
     return this;
   }
 

--- a/src/test/java/com/sanctionco/jmail/EmailTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailTest.java
@@ -190,6 +190,20 @@ class EmailTest {
   }
 
   @Test
+  void ensureNormalizedSkipsDomainAsciiConversion() {
+    String address = "you@test.com";
+
+    assertThat(Email.of(address))
+        .isPresent().get()
+        .returns(
+            "you@test.com",
+            email -> email.normalized(NormalizationOptions
+                .builder()
+                .convertDomainToAscii()
+                .build()));
+  }
+
+  @Test
   void ensureNormalizedConvertsLocalPartAndDomain() {
     String address = "Äffintest½@déjà.VU.straße.example.com";
 

--- a/src/test/java/com/sanctionco/jmail/EmailTest.java
+++ b/src/test/java/com/sanctionco/jmail/EmailTest.java
@@ -175,6 +175,36 @@ class EmailTest {
             .build()));
   }
 
+  @Test
+  void ensureNormalizedConvertsDomainToAscii() {
+    String address = "you@déjà.VU.straße.example.com";
+
+    assertThat(Email.of(address))
+        .isPresent().get()
+        .returns(
+            "you@xn--dj-kia8a.vu.xn--strae-oqa.example.com",
+            email -> email.normalized(NormalizationOptions
+                .builder()
+                .convertDomainToAscii()
+                .build()));
+  }
+
+  @Test
+  void ensureNormalizedConvertsLocalPartAndDomain() {
+    String address = "Äffintest½@déjà.VU.straße.example.com";
+
+    assertThat(Email.of(address))
+        .isPresent().get()
+        .returns(
+            "Äffintest1⁄2@xn--dj-kia8a.vu.xn--strae-oqa.example.com",
+            email -> email.normalized(NormalizationOptions
+                .builder()
+                .adjustCase(CaseOption.NO_CHANGE)
+                .performUnicodeNormalization()
+                .convertDomainToAscii()
+                .build()));
+  }
+
   @ParameterizedTest(name = "{0}")
   @CsvFileSource(resources = "/valid-addresses.csv", numLinesToSkip = 1)
   void ensureNormalizedStripsQuotesForAllValidAddresses(String address) {

--- a/src/test/java/com/sanctionco/jmail/normalization/IDNConverterTest.java
+++ b/src/test/java/com/sanctionco/jmail/normalization/IDNConverterTest.java
@@ -1,0 +1,161 @@
+package com.sanctionco.jmail.normalization;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IDNConverterTest {
+
+  @ParameterizedTest(name = "{0} -> {1}")
+  @MethodSource("provideLabelsForAsciiConversion")
+  public void testLabelsToASCII(List<String> input, String expected) {
+    String result = IDNConverter.labelsToAsciiDomain(input);
+    assertEquals(expected, result, "Failed to convert labels: " + input);
+  }
+
+  private static Stream<Arguments> provideLabelsForAsciiConversion() {
+    return Stream.of(
+        // German domains
+        Arguments.of(
+            Arrays.asList("münchen", "de"),
+            "xn--mnchen-3ya.de"
+        ),
+        Arguments.of(
+            Arrays.asList("düsseldorf", "de"),
+            "xn--dsseldorf-q9a.de"
+        ),
+        Arguments.of(
+            Arrays.asList("größe", "de"),
+            "xn--gre-6ka8i.de"
+        ),
+
+        // French domains
+        Arguments.of(
+            Arrays.asList("café", "fr"),
+            "xn--caf-dma.fr"
+        ),
+        Arguments.of(
+            Arrays.asList("français", "fr"),
+            "xn--franais-xxa.fr"
+        ),
+        Arguments.of(
+            Arrays.asList("naïve", "fr"),
+            "xn--nave-6pa.fr"
+        ),
+
+        // Spanish domains
+        Arguments.of(
+            Arrays.asList("españa", "es"),
+            "xn--espaa-rta.es"
+        ),
+        Arguments.of(
+            Arrays.asList("corazon", "es"),
+            "corazon.es"
+        ),
+        Arguments.of(
+            Arrays.asList("josé", "es"),
+            "xn--jos-dma.es"
+        ),
+
+        // Russian domains
+        Arguments.of(
+            Arrays.asList("москва", "ru"),
+            "xn--80adxhks.ru"
+        ),
+        Arguments.of(
+            Arrays.asList("пример", "рф"),
+            "xn--e1afmkfd.xn--p1ai"
+        ),
+        Arguments.of(
+            Arrays.asList("тест", "ru"),
+            "xn--e1aybc.ru"
+        ),
+
+        // Chinese domains
+        Arguments.of(
+            Arrays.asList("中国", "cn"),
+            "xn--fiqs8s.cn"
+        ),
+        Arguments.of(
+            Arrays.asList("北京", "中国"),
+            "xn--1lq90i.xn--fiqs8s"
+        ),
+        Arguments.of(
+            Arrays.asList("例え", "jp"),
+            "xn--r8jz45g.jp"
+        ),
+
+        // Japanese domains
+        Arguments.of(
+            Arrays.asList("日本", "jp"),
+            "xn--wgv71a.jp"
+        ),
+        Arguments.of(
+            Arrays.asList("テスト", "jp"),
+            "xn--zckzah.jp"
+        ),
+
+        // Greek domains
+        Arguments.of(
+            Arrays.asList("ελλάδα", "gr"),
+            "xn--hxakic4aa.gr"
+        ),
+        Arguments.of(
+            Arrays.asList("παράδειγμα", "gr"),
+            "xn--hxajbheg2az3al.gr"
+        ),
+
+        // Korean domains
+        Arguments.of(
+            Arrays.asList("한국", "kr"),
+            "xn--3e0b707e.kr"
+        ),
+        Arguments.of(
+            Arrays.asList("테스트", "kr"),
+            "xn--9t4b11yi5a.kr"
+        ),
+
+        // Mixed case and multiple labels
+        Arguments.of(
+            Arrays.asList("MÜNCHEN", "DE"),
+            "xn--mnchen-3ya.de"
+        ),
+        Arguments.of(
+            Arrays.asList("subdomain", "münchen", "de"),
+            "subdomain.xn--mnchen-3ya.de"
+        ),
+
+        // Already ASCII
+        Arguments.of(
+            Arrays.asList("example", "com"),
+            "example.com"
+        ),
+        Arguments.of(
+            Arrays.asList("google", "com"),
+            "google.com"
+        ),
+        Arguments.of(
+            Arrays.asList("mail", "co", "uk"),
+            "mail.co.uk"
+        )
+    );
+  }
+
+  @Test
+  void handlesNullAndEmpty() {
+    assertEquals("", IDNConverter.labelsToAsciiDomain(null));
+    assertEquals("", IDNConverter.labelsToAsciiDomain(Collections.emptyList()));
+
+    assertEquals("", IDNConverter.labelsToAsciiDomain(Collections.singletonList(null)));
+    assertEquals("", IDNConverter.labelsToAsciiDomain(Collections.singletonList("")));
+    assertEquals(" ", IDNConverter.labelsToAsciiDomain(Collections.singletonList(" ")));
+  }
+}


### PR DESCRIPTION
Long-awaited feature from #149 🙂

ASCII-fying the entire email is not feasible, but we can provide an ASCII version of the domain as part of normalization.